### PR TITLE
Cosmetic fixes

### DIFF
--- a/src/batchrender.cc
+++ b/src/batchrender.cc
@@ -86,7 +86,7 @@ void BatchRenderDialog::choose_file ()
 QString BatchRenderDialog::get_file_template ()
 {
 	QString t = ui->fileTemplateEdit->text ();
-	bool has_pat = t.contains ("%p");
+	bool has_pat = t.contains ("%n");
 	bool has_png = t.endsWith (".png");
 	QString t_no_suffix = has_png ? t.chopped (4) : t;
 	if (!has_pat) {

--- a/src/batchrender.ui
+++ b/src/batchrender.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Batch Render</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">


### PR DESCRIPTION
Give the batch render form a title instead of the default 'Form'.

This might be an actual bug: %n instead of %p in filename template pattern detection.